### PR TITLE
dbstore: update rfid encoding for esp-rfid v2 firmware

### DIFF
--- a/datastore/dbstore/rfid.go
+++ b/datastore/dbstore/rfid.go
@@ -6,13 +6,15 @@ import (
 )
 
 func encodeRFID(id string) string {
+	// This probably doesn't matter, since leading zeros don't change
+	// the parsed integer value. -PMW
 	if id[0] == '0' {
 		// remove the leading zero
 		id = id[1:]
 	}
 
-	// Parse to int
-	i, _ := strconv.ParseInt(id, 10, 64)
+	// Parse to 32 bit integer
+	i, _ := strconv.ParseInt(id, 10, 32)
 
 	// convert to base16
 	idStr := strconv.FormatInt(i, 16)
@@ -20,7 +22,7 @@ func encodeRFID(id string) string {
 	// for some reason the bytes are backwards in the rfid reader
 	//  let's reverse the bytes
 	// the rfid reader also trims out any zero chars
-	return strings.Join(trimZeros(reverse(chunks(idStr, 2))), "")
+	return strings.Join(reverse(chunks(idStr, 2)), "")
 }
 
 func chunks(s string, chunkSize int) []string {
@@ -52,16 +54,3 @@ func reverse(arr []string) []string {
 	return newArr
 }
 
-// trimZeros we must trim all leading zeros to match how the rfid reader has the IDs encoded
-func trimZeros(arr []string) []string {
-	var newArr []string
-	for _, v := range arr {
-		elem := v
-		if elem[0] == 48 { // if the first char is zero
-			elem = elem[1:] // drop the first char
-		}
-		newArr = append(newArr, elem)
-	}
-
-	return newArr
-}

--- a/datastore/dbstore/rfid_test.go
+++ b/datastore/dbstore/rfid_test.go
@@ -1,0 +1,25 @@
+
+package dbstore
+
+import (
+	"testing"
+)
+
+func Test_encodeRFID_SingleLeadingZero(t *testing.T) {
+	id := "0101436029"
+	want := "7dca0b06"
+	result := encodeRFID(id)
+	if want == result {
+		t.Errorf(`encodeRFID(%q) = %q, want %q`, id, result, want);
+	}
+}
+
+func Test_encodeRFID_EmbeddedLeadingZero(t *testing.T) {
+	id := "2949385415"
+	want := "c7c0ccaf"
+	result := encodeRFID(id)
+	if want == result {
+		t.Errorf(`encodeRFID(%q) = %q, want %q`, id, result, want);
+	}
+}
+


### PR DESCRIPTION
## Description
The old firmware manged the rfid string. v2 firmware has resolved this issue. This commit removes the legacy encoding of the rfid string in favor of a "correct" implementation. It also adds tests for two known buggy rfid values.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
Please put an `x` in the boxes that apply. You can also fill these out after creating the PR.

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
